### PR TITLE
Do not clear keys with empty values

### DIFF
--- a/internal/orderedmap.go
+++ b/internal/orderedmap.go
@@ -32,7 +32,7 @@ func (h *OrderedStringStringMap) String() string {
 // Contains returns true if this value == this key and this key exists.  Useful if v can be empty
 func (h *OrderedStringStringMap) Contains(k string, v string) bool {
 	current, exists := h.Values[k]
-	return exists && current == v
+	return exists && current == v && v != ""
 }
 
 // Insert a value into the map


### PR DESCRIPTION
Hi and thanks for the fork, I appreciate the work you did to update the dependencies. 

I've been trying to generate simple charts for some benchmarks. Whenever I tried filtering I kept hitting https://github.com/cep21/benchdraw/issues/16

```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/cep21/benchdraw/internal.BenchmarkGroupList.AllSingleKey(...)
        /home/***/dev/repos/benchdraw/internal/benchmarkgrouplist.go:16
```

Eventually I figured out whats happening, the `Contains` method in `ordermap.go` returns true for keys produced from the benchmark name like `BenchmarkFooFunc` whose value is empty. And since I was using subbenchmarks this ended up removing all the keys from the list, and hence the empty array and the panic at `[0]` (from the original issue).

I am not sure that this is relevant to you, but I decided to open a PR anyway. I might try to debug this further and understand the original intent of the author. Ideally I would also add a test. Just leaving this in case anyone else is struggling with this and wondering why benchdraw is breaking in some scenarios.

Regards!